### PR TITLE
Fix wind gust key prefix

### DIFF
--- a/data_treatment.py
+++ b/data_treatment.py
@@ -55,12 +55,12 @@ def get_metar_features(metar, name=""):
         features[name+'wind_direction'] = direction
         features[name+'wind_velocity'] = velocity
         features[name+'wind_status'] = status
-        features["wind_gust"] = wind_gust
+        features[name+'wind_gust'] = wind_gust
     else:
         features[name+'wind_direction'] = None
         features[name+'wind_velocity'] = None
         features[name+'wind_status'] = None
-        features["wind_gust"] = None
+        features[name+'wind_gust'] = None
 
     # Append peak wind
     features[name+'peak_wind'] = metar.peak_wind() if metar.peak_wind() not in [None, "missing"] else None

--- a/tests/test_data_treatment.py
+++ b/tests/test_data_treatment.py
@@ -1,0 +1,36 @@
+import types
+from datetime import datetime
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from data_treatment import get_metar_features
+
+class Dummy:
+    def __init__(self, temp=25, dewpt=20, wind_str="N at 10 knots"):
+        self.time = datetime(2023, 1, 1, 12, 0, 0)
+        self.temp = types.SimpleNamespace(string=lambda unit: f"{temp} C")
+        self.dewpt = types.SimpleNamespace(string=lambda unit: f"{dewpt} C")
+        self.wind_str = wind_str
+        self.wind = lambda: self.wind_str
+        self.press = types.SimpleNamespace(string=lambda unit: "1010 mb")
+    def peak_wind(self):
+        return None
+    def wind_shift(self):
+        return None
+    def visibility(self, m):
+        return None
+    def runway_visual_range(self, m):
+        return None
+    def present_weather(self):
+        return None
+    def sky_conditions(self):
+        return None
+
+
+def test_get_metar_features_prefix():
+    metar = Dummy()
+    features = get_metar_features(metar, name="pref")
+    assert 'pref_wind_gust' in features
+    assert 'pref_wind_direction' in features


### PR DESCRIPTION
## Summary
- ensure `get_metar_features` uses prefix for `wind_gust`
- add regression test covering this behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446fded2d88331bed9969626bb7385